### PR TITLE
Application SAT Solver (Part 2)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/spf13/pflag v1.0.5
+	github.com/spjmurray/go-sat v0.1.1
 	github.com/stretchr/testify v1.9.0
 	github.com/unikorn-cloud/core v0.1.80
 	github.com/unikorn-cloud/identity v0.2.44

--- a/go.sum
+++ b/go.sum
@@ -126,6 +126,8 @@ github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spjmurray/go-sat v0.1.1 h1:XWptzXLXu5XRt1xPnl1WpF+lKy2/YebetDBS9aazTMs=
+github.com/spjmurray/go-sat v0.1.1/go.mod h1:PfXzQbyb3Tucoyw9jNb3/Kj0VQUrK2KQ8F1NWBvCPPk=
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=


### PR DESCRIPTION
Part 1 detected where multiple dependencies affected version selection and combined them to choose one, if any, that satisfied those constraints.  What it didn't do was handle when a version has already been selected and a new constraint was not met.  This detects that condition and rolls back to the previous descision and tries with a new version, repeating the process until the problem is satisfied or not.