### PR TITLE
Remove Orphaned Applications

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spjmurray/go-sat v0.3.1
 	github.com/stretchr/testify v1.9.0
-	github.com/unikorn-cloud/core v0.1.82
+	github.com/unikorn-cloud/core v0.1.83
 	github.com/unikorn-cloud/identity v0.2.44
 	github.com/unikorn-cloud/kubernetes v0.2.47
 	go.opentelemetry.io/otel/sdk v1.31.0

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
-github.com/unikorn-cloud/core v0.1.82 h1:MoDkQeHrjlyvjExYk/V8LeXO2T8pLYkaijpwSy6D/Ys=
-github.com/unikorn-cloud/core v0.1.82/go.mod h1:wEKzCwAnIyTbo27l++Wl+gK95TAxMsFS3y3jbFB03aw=
+github.com/unikorn-cloud/core v0.1.83 h1:cF6DKskXk3FSs1W4Y8hgWypm7D+iLRpV09a8mpcuW5s=
+github.com/unikorn-cloud/core v0.1.83/go.mod h1:wEKzCwAnIyTbo27l++Wl+gK95TAxMsFS3y3jbFB03aw=
 github.com/unikorn-cloud/identity v0.2.44 h1:tXV/qsJ77Dkx8ba8gnBFXHWUgBNsJ2oo/5TjnyhkH7U=
 github.com/unikorn-cloud/identity v0.2.44/go.mod h1:JMbS6iTYzt0OVt5AkqZys3WVnpLabGvUl8kGWcxzFZI=
 github.com/unikorn-cloud/kubernetes v0.2.47 h1:dc2V0RWabhZ6hUwrRkdWVMI48eNq5oZbgAGS3RC1r+I=


### PR DESCRIPTION
We can provision, deprovision, upgrade, downgrade, the only missing bit functionally is removing items no longer in the graph that still exist in the CD driver.